### PR TITLE
AAF initial skill raised from 0 to 0.35

### DIFF
--- a/Antistasi/initVar.sqf
+++ b/Antistasi/initVar.sqf
@@ -200,7 +200,7 @@ AS_Pset("resourcesFIA",1000); //Initial FIA money pool value
 
 AS_Pset("resourcesAAF",0); //Initial AAF resources
 AS_Pset("skillFIA",0); //Initial skill level of FIA
-AS_Pset("skillAAF",0); //Initial skill level of AAF
+AS_Pset("skillAAF",0.35); //Initial skill level of AAF
 AS_Pset("NATOsupport",5); //Initial NATO support
 AS_Pset("CSATsupport",5); //Initial CSAT support
 


### PR DESCRIPTION
Skill raised to simulate the better trained regular army while still incorporating a feeling of progression among their ranks.

It should now mirror the skills of a newly recruited unit.